### PR TITLE
fix: improve binary detection with extension whitelist priority

### DIFF
--- a/src/features/copy-content/detect-binary.ts
+++ b/src/features/copy-content/detect-binary.ts
@@ -1,11 +1,91 @@
+import path from "node:path";
 import { fromFile } from "file-type";
+import { languageMap } from "./language-map";
+
+// Known binary extensions that should always be treated as binary
+const KNOWN_BINARY_EXTENSIONS = new Set([
+	"png",
+	"jpg",
+	"jpeg",
+	"gif",
+	"bmp",
+	"ico",
+	"webp",
+	"avif",
+	"tiff",
+	"tif",
+	"svg", // SVG is text but often treated as binary asset
+	"mp3",
+	"mp4",
+	"wav",
+	"ogg",
+	"webm",
+	"avi",
+	"mov",
+	"mkv",
+	"flac",
+	"aac",
+	"pdf",
+	"doc",
+	"docx",
+	"xls",
+	"xlsx",
+	"ppt",
+	"pptx",
+	"zip",
+	"tar",
+	"gz",
+	"rar",
+	"7z",
+	"bz2",
+	"xz",
+	"exe",
+	"dll",
+	"so",
+	"dylib",
+	"bin",
+	"dat",
+	"woff",
+	"woff2",
+	"ttf",
+	"otf",
+	"eot",
+	"class",
+	"jar",
+	"pyc",
+	"pyo",
+	"o",
+	"a",
+	"lib",
+	"node",
+	"wasm",
+]);
 
 export async function detectBinary(fullPath: string): Promise<boolean> {
+	const ext = path.extname(fullPath).replace(".", "").toLowerCase();
+	const basename = path.basename(fullPath);
+
+	// 1️⃣ Priority 1: Known text extensions (from languageMap) → not binary
+	if (languageMap[ext] || languageMap[basename]) {
+		return false;
+	}
+
+	// 2️⃣ Priority 2: Known binary extensions → is binary
+	if (KNOWN_BINARY_EXTENSIONS.has(ext)) {
+		return true;
+	}
+
+	// 3️⃣ Priority 3: Content-based detection using istextorbinary
+	const itb = await import("istextorbinary");
+	if (!itb.isText(fullPath, undefined)) {
+		return true;
+	}
+
+	// 4️⃣ Priority 4: Magic bytes detection (lowest priority)
 	const ft = await fromFile(fullPath);
 	if (ft) {
 		return !ft.mime.startsWith("text/");
 	}
 
-	const itb = await import("istextorbinary");
-	return !itb.isText(fullPath, undefined);
+	return false;
 }


### PR DESCRIPTION
- Prioritize known text extensions from languageMap (not binary)
- Add KNOWN_BINARY_EXTENSIONS set for common binary formats
- Use istextorbinary for content-based detection as fallback
- Move file-type magic bytes detection to lowest priority

This fixes false positive binary detection for files like .svelte, .vue, .tsx that could be misidentified as binary due to magic bytes matching.

修复一个判断二进制的问题 目前.sevelte文件会被判断成二进制